### PR TITLE
Add a route for `/service` to return all available services.

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ func main() {
 		}
 	}()
 
-	router.PathPrefix("/service/").Handler(http.StripPrefix("/service/", srv.Handler()))
+	router.Path("/service").Handler(srv.AllServicesHandler())
+	router.PathPrefix("/service/").Handler(http.StripPrefix("/service/", srv.ServiceQueryHandler()))
 
 	log.Printf("[INFO] Ready to serve at %v", address)
 	s := http.Server{


### PR DESCRIPTION
This PR simply adds a `/service` handler which returns all available services.  It's a useful endpoint in itself but also works very well as a health check endpoint for the keynoter service itself.